### PR TITLE
Removed +1 in month

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -32,7 +32,7 @@ export class AirDatepicker implements OnInit {
     }
 
     setTime () {
-      this.airDate.setTime(+ Date.UTC(this.airCalendar.year, this.airCalendar.month + 1, this.airCalendar.date, this.airCalendar.hour, this.airCalendar.minute));
+      this.airDate.setTime(+ Date.UTC(this.airCalendar.year, this.airCalendar.month, this.airCalendar.date, this.airCalendar.hour, this.airCalendar.minute));
       this.airChange.emit(this.airDate);
     }
 }


### PR DESCRIPTION
I have removed the "+1" in the airCalendar.month inside setTime func.
I had to remove it because with +1 when you click on a day in the calendar the month set in the variable is incremented by 1.
I had 10 November and clicking on 11 November my variable become 11 December.